### PR TITLE
Fix nao_leds.launch

### DIFF
--- a/nao_apps/launch/nao_leds.launch
+++ b/nao_apps/launch/nao_leds.launch
@@ -8,5 +8,5 @@
   <arg name="nao_ip" default="$(optenv NAO_IP 127.0.0.1)" />
   <arg name="nao_port" default="$(optenv NAO_PORT 9559)" />
 
-  <node pkg="nao_apps" type="nao_speech.py" name="nao_speech" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)"  />
+  <node pkg="nao_apps" type="nao_leds.py" name="nao_leds" required="true" args="--pip=$(arg nao_ip) --pport=$(arg nao_port)"  />
 </launch>


### PR DESCRIPTION
Current nao_leds.launch is completely broken, it launches actually nao_speech.py, and there are not launch file
for nao_leds.py.
https://github.com/ros-naoqi/nao_robot/pull/11 will solve the problem if it has been merged.

If it takes some more time to merge that pull request, could you merge this to fix it?
This will not conflict with the pull request, though it might need to be rebased.