### PR TITLE
launch/nao_full.launch : support nao_port in launch/naoqi_driver.launch https://github.com/ros-naoqi/naoqi_driver/pull/52

### DIFF
--- a/nao_bringup/launch/nao_full.launch
+++ b/nao_bringup/launch/nao_full.launch
@@ -11,6 +11,7 @@
   <!-- naoqi driver -->
   <include file="$(find naoqi_driver)/launch/naoqi_driver.launch" ns="$(arg namespace)" >
     <arg name="nao_ip"            value="$(arg nao_ip)" />
+    <arg name="nao_port"          value="$(arg nao_port)" />
     <arg name="roscore_ip"        value="$(arg roscore_ip)" />
     <arg name="network_interface" value="$(arg network_interface)" />
   </include>


### PR DESCRIPTION
this requires https://github.com/ros-naoqi/naoqi_driver/pull/52