### PR TITLE
[nao_apps] Fixing bug generated when renaming in naoqi_bridge_msgs TactileTouch to HeadTouch

### DIFF
--- a/nao_apps/nodes/nao_tactile.py
+++ b/nao_apps/nodes/nao_tactile.py
@@ -35,7 +35,7 @@
 import rospy
 
 import naoqi
-from naoqi_bridge_msgs.msg import TactileTouch, Bumper
+from naoqi_bridge_msgs.msg import HeadTouch, Bumper
 from std_msgs.msg import Bool
 from naoqi_driver.naoqi_node import NaoqiNode
 from naoqi import ( ALModule, ALBroker, ALProxy )
@@ -83,9 +83,9 @@ class NaoTactile(ALModule):
         rospy.init_node('nao_tactile')
 
         # init. messages:
-        self.tactile = TactileTouch()
+        self.tactile = HeadTouch()
         self.bumper = Bumper()
-        self.tactilePub = rospy.Publisher("tactile_touch", TactileTouch, queue_size=10)
+        self.tactilePub = rospy.Publisher("tactile_touch", HeadTouch, queue_size=10)
         self.bumperPub = rospy.Publisher("bumper", Bumper, queue_size=10)
 
         try:
@@ -101,12 +101,12 @@ class NaoTactile(ALModule):
             self.footContactPub = rospy.Publisher("foot_contact", Bool, latch=True, queue_size=10)
             self.footContactPub.publish(footContact > 0.0)
 
-        # constants in TactileTouch and Bumper will not be available in callback functions
+        # constants in HeadTouch and Bumper will not be available in callback functions
         # as they are executed in the parent broker context (i.e. on robot),
         # so they have to be copied to member variables
-        self.tactileTouchFrontButton = TactileTouch.buttonFront;
-        self.tactileTouchMiddleButton = TactileTouch.buttonMiddle;
-        self.tactileTouchRearButton = TactileTouch.buttonRear;
+        self.tactileTouchFrontButton = HeadTouch.buttonFront;
+        self.tactileTouchMiddleButton = HeadTouch.buttonMiddle;
+        self.tactileTouchRearButton = HeadTouch.buttonRear;
         self.bumperRightButton = Bumper.right;
         self.bumperLeftButton = Bumper.left;
 


### PR DESCRIPTION
Hello,

Commit 9b92dba in ros-naoqi/naoqi_bridge_msgs caused an error when launching nao_apps tacticle.launch

This pull request is to fix the problem. Hope I've done everything alright.

Cheers,
Felip

Error:
```
$ roslaunch nao_apps tacticle.launch nao_ip:=10.42.0.93

   File "/home/fmarti/rch-ros_ws/src/nao_robot/nao_apps/nodes/nao_tactile.py", line 86, in __init__
    self.tactile = TactileTouch()
NameError: global name 'TactileTouch' is not defined
================================================================================REQUIRED process [nao_tactile-1] has died!
process has died [pid 9397, exit code 1, cmd /home/fmarti/rch-ros_ws/src/nao_robot/nao_apps/nodes/nao_tactile.py --pip=10.42.0.93 --pport=9559 __name:=nao_tactile __log:=/home/fmarti/.ros/log/8f3dbce2-af01-11e6-a816-9cebe82e040a/nao_tactile-1.log].
log file: /home/fmarti/.ros/log/8f3dbce2-af01-11e6-a816-9cebe82e040a/nao_tactile-1*.log
Initiating shutdown!
================================================================================
[nao_tactile-1] killing on exit

```
