### PR TITLE
[package.xml] fix dependency on naoqi_bridge (meta-package)

### DIFF
--- a/nao_apps/package.xml
+++ b/nao_apps/package.xml
@@ -15,7 +15,10 @@
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>humanoid_nav_msgs</run_depend>
-  <run_depend>naoqi_bridge</run_depend>
+  <run_depend>naoqi_apps</run_depend>
+  <run_depend>naoqi_navigation</run_depend>
+  <run_depend>naoqi_sensors_py</run_depend>
+  <run_depend>naoqi_tools</run_depend>
   <run_depend>naoqi_bridge_msgs</run_depend>
   <run_depend>naoqi_driver</run_depend>
   <run_depend>naoqi_driver_py</run_depend>


### PR DESCRIPTION
I deleted a dependency on `naoqi_bridge` (meta-package) and added each of package in `naoqi_bridge`.
reference: https://github.com/catkin/catkin_tools/issues/370#issuecomment-219157118

When executing `catkin bt`, I got this message.
```
Abandoned <<< nao_apps                            [ Depends on unknown jobs: naoqi_bridge ]
```
The whole log is below.
I'm using ros indigo, ubuntu 14.04.
```
kochigami@kochigami-ThinkPad-T450:~/catkin_ws/src/nao_robot/nao_apps$ catkin bt
==> Expanding alias 'bt' from 'catkin bt' to 'catkin b --this'
==> Expanding alias 'b' from 'catkin b --this' to 'catkin build --this'
--------------------------------------------------------------
Profile:                     default
Extending:          [cached] /opt/ros/indigo
Workspace:                   /home/kochigami/catkin_ws
--------------------------------------------------------------
Source Space:       [exists] /home/kochigami/catkin_ws/src
Log Space:          [exists] /home/kochigami/catkin_ws/logs
Build Space:        [exists] /home/kochigami/catkin_ws/build
Devel Space:        [exists] /home/kochigami/catkin_ws/devel
Install Space:      [unused] /home/kochigami/catkin_ws/install
DESTDIR:            [unused] None
--------------------------------------------------------------
Devel Space Layout:          linked
Install Space Layout:        None
--------------------------------------------------------------
Additional CMake Args:       None
Additional Make Args:        None
Additional catkin Make Args: None
Internal Make Job Server:    True
Cache Job Environments:      False
--------------------------------------------------------------
Whitelisted Packages:        None
Blacklisted Packages:        None
--------------------------------------------------------------
Workspace configuration appears valid.
--------------------------------------------------------------
[build] Found '83' packages in 0.0 seconds.                                    
[build] Package table is up to date.                                           
Abandoned <<< nao_apps                         [ Depends on unknown jobs: naoqi_bridge ]
Starting  >>> naoqi_apps                                                       
Starting  >>> naoqi_bridge_msgs                                                
Starting  >>> naoqi_tools                                                      
Finished  <<< naoqi_apps                       [ 0.2 seconds ]                 
Finished  <<< naoqi_tools                      [ 0.3 seconds ]                 
Finished  <<< naoqi_bridge_msgs                [ 3.3 seconds ]                 
Starting  >>> naoqi_driver                                                     
Starting  >>> naoqi_driver_py                                                  
Starting  >>> naoqi_pose                                                       
Finished  <<< naoqi_driver_py                  [ 0.2 seconds ]                 
Starting  >>> naoqi_sensors_py                                                 
Finished  <<< naoqi_pose                       [ 0.2 seconds ]                 
Finished  <<< naoqi_sensors_py                 [ 0.3 seconds ]                 
Finished  <<< naoqi_driver                     [ 0.6 seconds ]                 
[build] Summary: 7 of 8 packages succeeded.                                    
[build]   Ignored:   75 packages were skipped or are blacklisted.              
[build]   Warnings:  None.                                                     
[build]   Abandoned: 1 packages were abandoned.                                
[build]   Failed:    None.                                                     
[build] Runtime: 4.7 seconds total.   
```

